### PR TITLE
APIクライアント作ってGithubAPIへリクエストを可能に

### DIFF
--- a/zozo-ios-engineer-codecheck.xcodeproj/project.pbxproj
+++ b/zozo-ios-engineer-codecheck.xcodeproj/project.pbxproj
@@ -16,7 +16,7 @@
 		49CD8F4E2C2A5F5700E78E9E /* APIClientViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49CD8F4D2C2A5F5700E78E9E /* APIClientViewController.swift */; };
 		49CD8F502C2A719500E78E9E /* APIClientViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49CD8F4F2C2A719500E78E9E /* APIClientViewModel.swift */; };
 		49CD8F532C2E4BF100E78E9E /* HTTPMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49CD8F522C2E4BF100E78E9E /* HTTPMethod.swift */; };
-		49CD8F552C2E4C4F00E78E9E /* APIRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49CD8F542C2E4C4F00E78E9E /* APIRequest.swift */; };
+		49CD8F552C2E4C4F00E78E9E /* APIRequestProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49CD8F542C2E4C4F00E78E9E /* APIRequestProtocol.swift */; };
 		49CD8F572C2E573700E78E9E /* APIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49CD8F562C2E573700E78E9E /* APIClient.swift */; };
 		49CD8F592C2E581500E78E9E /* HTTPError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49CD8F582C2E581500E78E9E /* HTTPError.swift */; };
 		49CD8F5B2C2E83CC00E78E9E /* SearchRepositoriesRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49CD8F5A2C2E83CC00E78E9E /* SearchRepositoriesRequest.swift */; };
@@ -54,7 +54,7 @@
 		49CD8F4D2C2A5F5700E78E9E /* APIClientViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClientViewController.swift; sourceTree = "<group>"; };
 		49CD8F4F2C2A719500E78E9E /* APIClientViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClientViewModel.swift; sourceTree = "<group>"; };
 		49CD8F522C2E4BF100E78E9E /* HTTPMethod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPMethod.swift; sourceTree = "<group>"; };
-		49CD8F542C2E4C4F00E78E9E /* APIRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIRequest.swift; sourceTree = "<group>"; };
+		49CD8F542C2E4C4F00E78E9E /* APIRequestProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIRequestProtocol.swift; sourceTree = "<group>"; };
 		49CD8F562C2E573700E78E9E /* APIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClient.swift; sourceTree = "<group>"; };
 		49CD8F582C2E581500E78E9E /* HTTPError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPError.swift; sourceTree = "<group>"; };
 		49CD8F5A2C2E83CC00E78E9E /* SearchRepositoriesRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchRepositoriesRequest.swift; sourceTree = "<group>"; };
@@ -160,7 +160,7 @@
 		49CD8F5F2C31BA7300E78E9E /* Request */ = {
 			isa = PBXGroup;
 			children = (
-				49CD8F542C2E4C4F00E78E9E /* APIRequest.swift */,
+				49CD8F542C2E4C4F00E78E9E /* APIRequestProtocol.swift */,
 				49CD8F5A2C2E83CC00E78E9E /* SearchRepositoriesRequest.swift */,
 			);
 			path = Request;
@@ -326,7 +326,7 @@
 				49CD8F4E2C2A5F5700E78E9E /* APIClientViewController.swift in Sources */,
 				49111BF02C251938009D66F8 /* AppDelegate.swift in Sources */,
 				49CD8F532C2E4BF100E78E9E /* HTTPMethod.swift in Sources */,
-				49CD8F552C2E4C4F00E78E9E /* APIRequest.swift in Sources */,
+				49CD8F552C2E4C4F00E78E9E /* APIRequestProtocol.swift in Sources */,
 				49111BF22C251938009D66F8 /* SceneDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/zozo-ios-engineer-codecheck.xcodeproj/project.pbxproj
+++ b/zozo-ios-engineer-codecheck.xcodeproj/project.pbxproj
@@ -15,6 +15,12 @@
 		49111C132C25193A009D66F8 /* zozo_ios_engineer_codecheckUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49111C122C25193A009D66F8 /* zozo_ios_engineer_codecheckUITestsLaunchTests.swift */; };
 		49CD8F4E2C2A5F5700E78E9E /* APIClientViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49CD8F4D2C2A5F5700E78E9E /* APIClientViewController.swift */; };
 		49CD8F502C2A719500E78E9E /* APIClientViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49CD8F4F2C2A719500E78E9E /* APIClientViewModel.swift */; };
+		49CD8F532C2E4BF100E78E9E /* HTTPMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49CD8F522C2E4BF100E78E9E /* HTTPMethod.swift */; };
+		49CD8F552C2E4C4F00E78E9E /* APIRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49CD8F542C2E4C4F00E78E9E /* APIRequest.swift */; };
+		49CD8F572C2E573700E78E9E /* APIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49CD8F562C2E573700E78E9E /* APIClient.swift */; };
+		49CD8F592C2E581500E78E9E /* HTTPError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49CD8F582C2E581500E78E9E /* HTTPError.swift */; };
+		49CD8F5B2C2E83CC00E78E9E /* SearchRepositoriesRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49CD8F5A2C2E83CC00E78E9E /* SearchRepositoriesRequest.swift */; };
+		49CD8F5D2C2E83FE00E78E9E /* SearchRepositoriesResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49CD8F5C2C2E83FE00E78E9E /* SearchRepositoriesResponse.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -47,6 +53,12 @@
 		49111C122C25193A009D66F8 /* zozo_ios_engineer_codecheckUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = zozo_ios_engineer_codecheckUITestsLaunchTests.swift; sourceTree = "<group>"; };
 		49CD8F4D2C2A5F5700E78E9E /* APIClientViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClientViewController.swift; sourceTree = "<group>"; };
 		49CD8F4F2C2A719500E78E9E /* APIClientViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClientViewModel.swift; sourceTree = "<group>"; };
+		49CD8F522C2E4BF100E78E9E /* HTTPMethod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPMethod.swift; sourceTree = "<group>"; };
+		49CD8F542C2E4C4F00E78E9E /* APIRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIRequest.swift; sourceTree = "<group>"; };
+		49CD8F562C2E573700E78E9E /* APIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClient.swift; sourceTree = "<group>"; };
+		49CD8F582C2E581500E78E9E /* HTTPError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPError.swift; sourceTree = "<group>"; };
+		49CD8F5A2C2E83CC00E78E9E /* SearchRepositoriesRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchRepositoriesRequest.swift; sourceTree = "<group>"; };
+		49CD8F5C2C2E83FE00E78E9E /* SearchRepositoriesResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchRepositoriesResponse.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -97,6 +109,7 @@
 		49111BEE2C251938009D66F8 /* zozo-ios-engineer-codecheck */ = {
 			isa = PBXGroup;
 			children = (
+				49CD8F512C2E4B4300E78E9E /* Data */,
 				49111BEF2C251938009D66F8 /* AppDelegate.swift */,
 				49111BF12C251938009D66F8 /* SceneDelegate.swift */,
 				49CD8F4D2C2A5F5700E78E9E /* APIClientViewController.swift */,
@@ -122,6 +135,35 @@
 				49111C122C25193A009D66F8 /* zozo_ios_engineer_codecheckUITestsLaunchTests.swift */,
 			);
 			path = "zozo-ios-engineer-codecheckUITests";
+			sourceTree = "<group>";
+		};
+		49CD8F512C2E4B4300E78E9E /* Data */ = {
+			isa = PBXGroup;
+			children = (
+				49CD8F5F2C31BA7300E78E9E /* Request */,
+				49CD8F5E2C31BA6B00E78E9E /* Response */,
+				49CD8F522C2E4BF100E78E9E /* HTTPMethod.swift */,
+				49CD8F562C2E573700E78E9E /* APIClient.swift */,
+				49CD8F582C2E581500E78E9E /* HTTPError.swift */,
+			);
+			path = Data;
+			sourceTree = "<group>";
+		};
+		49CD8F5E2C31BA6B00E78E9E /* Response */ = {
+			isa = PBXGroup;
+			children = (
+				49CD8F5C2C2E83FE00E78E9E /* SearchRepositoriesResponse.swift */,
+			);
+			path = Response;
+			sourceTree = "<group>";
+		};
+		49CD8F5F2C31BA7300E78E9E /* Request */ = {
+			isa = PBXGroup;
+			children = (
+				49CD8F542C2E4C4F00E78E9E /* APIRequest.swift */,
+				49CD8F5A2C2E83CC00E78E9E /* SearchRepositoriesRequest.swift */,
+			);
+			path = Request;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -277,8 +319,14 @@
 			buildActionMask = 2147483647;
 			files = (
 				49CD8F502C2A719500E78E9E /* APIClientViewModel.swift in Sources */,
+				49CD8F5B2C2E83CC00E78E9E /* SearchRepositoriesRequest.swift in Sources */,
+				49CD8F572C2E573700E78E9E /* APIClient.swift in Sources */,
+				49CD8F592C2E581500E78E9E /* HTTPError.swift in Sources */,
+				49CD8F5D2C2E83FE00E78E9E /* SearchRepositoriesResponse.swift in Sources */,
 				49CD8F4E2C2A5F5700E78E9E /* APIClientViewController.swift in Sources */,
 				49111BF02C251938009D66F8 /* AppDelegate.swift in Sources */,
+				49CD8F532C2E4BF100E78E9E /* HTTPMethod.swift in Sources */,
+				49CD8F552C2E4C4F00E78E9E /* APIRequest.swift in Sources */,
 				49111BF22C251938009D66F8 /* SceneDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/zozo-ios-engineer-codecheck/Data/APIClient.swift
+++ b/zozo-ios-engineer-codecheck/Data/APIClient.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 protocol APIClientProtocol {
-    func request<D: Decodable>(apiRequest: any APIRequest) async throws -> Result<D, HTTPError>
+    func request<D: Decodable>(apiRequest: any APIRequestProtocol) async throws -> Result<D, HTTPError>
 }
 
 class APIClient: APIClientProtocol {
@@ -30,7 +30,7 @@ class APIClient: APIClientProtocol {
     ///    let response: Result<SearchRepositoryResponse, HTTPError> = try await apiClient.request(apiRequest: apiRequest)
     /// }
     /// ```
-    func request<D: Decodable>(apiRequest: any APIRequest) async throws -> Result<D, HTTPError> {
+    func request<D: Decodable>(apiRequest: any APIRequestProtocol) async throws -> Result<D, HTTPError> {
         let request = apiRequest.buildURLRequest()
         let (data, response) = try await URLSession.shared.data(for: request)
         guard let httpStatus = response as? HTTPURLResponse else {

--- a/zozo-ios-engineer-codecheck/Data/APIClient.swift
+++ b/zozo-ios-engineer-codecheck/Data/APIClient.swift
@@ -1,0 +1,99 @@
+//
+//  APIClient.swift
+//  zozo-ios-engineer-codecheck
+//
+//  Created by yuki.hamada on 2024/06/28.
+//
+
+import Foundation
+
+protocol APIClientProtocol {
+    func request<D: Decodable>(apiRequest: any APIRequest) async throws -> Result<D, HTTPError>
+}
+
+class APIClient: APIClientProtocol {
+    /// APIから所得したJSONを変換するためのDecoder
+    ///
+    /// `total_count -> totalCount`
+    private static var decoder: JSONDecoder {
+        let jsonDecoder = JSONDecoder()
+        jsonDecoder.keyDecodingStrategy = .convertFromSnakeCase  // total_count -> totalCount
+        return jsonDecoder
+    }
+
+    /// URLSessionを用いたHTTPリクエスト
+    ///
+    /// ```
+    /// Task {
+    ///    let apiRequest = ~~~
+    ///    let apiClient = APIClient()
+    ///    let response: Result<SearchRepositoryResponse, HTTPError> = try await apiClient.request(apiRequest: apiRequest)
+    /// }
+    /// ```
+    func request<D: Decodable>(apiRequest: any APIRequest) async throws -> Result<D, HTTPError> {
+        let request = apiRequest.buildURLRequest()
+        let (data, response) = try await URLSession.shared.data(for: request)
+        guard let httpStatus = response as? HTTPURLResponse else {
+            return .failure(.responseError)
+        }
+
+        switch httpStatus.statusCode {
+        case 200..<300:
+            do {
+                let decodedData = try APIClient.decoder.decode(D.self, from: data)
+                return .success(decodedData)
+            } catch {
+                return .failure(.decodeError)
+            }
+        case 400..<600:
+            let error = errorHandling(statusCode: httpStatus.statusCode)
+            return .failure(error)
+        default:
+            return .failure(.unknownError)
+        }
+    }
+}
+
+// MARK: - extension
+
+extension APIClient {
+    /// 400, 500番台のエラーハンドリング
+    func errorHandling(statusCode: Int) -> HTTPError {
+        switch statusCode {
+        // 4xx クライアントエラー
+        case 400:
+            return .badRequest
+        case 401:
+            return .unauthorized
+        case 403:
+            return .forbidden
+        case 404:
+            return .notFound
+        case 405:
+            return .methodNotAllowed
+        case 408:
+            return .requestTimeout
+        case 409:
+            return .conflict
+        case 429:
+            return .tooManyRequests
+        case 400...499:
+            return .clientError(statusCode)
+        // 5xx サーバーエラー
+        case 500:
+            return .internalServerError
+        case 501:
+            return .notImplemented
+        case 502:
+            return .badGateway
+        case 503:
+            return .serviceUnavailable
+        case 504:
+            return .gatewayTimeout
+        case 500...599:
+            return .serverError(statusCode)
+        default:
+            return .unknownError
+        }
+    }
+}

--- a/zozo-ios-engineer-codecheck/Data/APIClient.swift
+++ b/zozo-ios-engineer-codecheck/Data/APIClient.swift
@@ -12,7 +12,7 @@ protocol APIClientProtocol {
 }
 
 class APIClient: APIClientProtocol {
-    /// APIから所得したJSONを変換するためのDecoder
+    /// APIから取得したJSONを変換するためのDecoder
     ///
     /// `total_count -> totalCount`
     private static var decoder: JSONDecoder {

--- a/zozo-ios-engineer-codecheck/Data/HTTPError.swift
+++ b/zozo-ios-engineer-codecheck/Data/HTTPError.swift
@@ -1,0 +1,80 @@
+//
+//  HTTPError.swift
+//  zozo-ios-engineer-codecheck
+//
+//  Created by yuki.hamada on 2024/06/28.
+//
+
+import Foundation
+
+enum HTTPError: Error {
+    /// レスポンスを受け取れなかった
+    case responseError
+
+    /// レスポンスを正しくデコードできなかった
+    case decodeError
+
+    // 4xx クライアントエラー
+    case badRequest  // 400 Bad Request
+    case unauthorized  // 401 Unauthorized
+    case forbidden  // 403 Forbidden
+    case notFound  // 404 Not Found
+    case methodNotAllowed  // 405 Method Not Allowed
+    case requestTimeout  // 408 Request Timeout
+    case conflict  // 409 Conflict
+    case tooManyRequests  // 429 Too Many Requests
+    case clientError(Int)  // その他の4xxエラー
+
+    // 5xx サーバーエラー
+    case internalServerError  // 500 Internal Server Error
+    case notImplemented  // 501 Not Implemented
+    case badGateway  // 502 Bad Gateway
+    case serviceUnavailable  // 503 Service Unavailable
+    case gatewayTimeout  // 504 Gateway Timeout
+    case serverError(Int)  // その他の5xxエラー
+
+    case unknownError  // 未知のエラー
+
+    var errorDescription: String {
+        switch self {
+        case .responseError:
+            return "レスポンスを受信できませんでした"
+        case .decodeError:
+            return "データのデコード中にエラーが発生しました"
+        // 4xx クライアントエラー
+        case .badRequest:
+            return "リクエストが無効です (400)"
+        case .unauthorized:
+            return "認証に失敗しました (401)"
+        case .forbidden:
+            return "アクセスが拒否されました (403)"
+        case .notFound:
+            return "リソースが見つかりません (404)"
+        case .methodNotAllowed:
+            return "許可されていないメソッドです (405)"
+        case .requestTimeout:
+            return "リクエストがタイムアウトしました (408)"
+        case .conflict:
+            return "リクエストが競合しています (409)"
+        case .tooManyRequests:
+            return "リクエスト回数の上限を超えました (429)"
+        case .clientError(let code):
+            return "クライアントエラーが発生しました (\(code))"
+        // 5xx サーバーエラー
+        case .internalServerError:
+            return "サーバー内部でエラーが発生しました (500)"
+        case .notImplemented:
+            return "機能が実装されていません (501)"
+        case .badGateway:
+            return "不正なゲートウェイです (502)"
+        case .serviceUnavailable:
+            return "サービスが利用できません (503)"
+        case .gatewayTimeout:
+            return "ゲートウェイがタイムアウトしました (504)"
+        case .serverError(let code):
+            return "サーバーエラーが発生しました (\(code))"
+        case .unknownError:
+            return "未知のエラーが発生しました"
+        }
+    }
+}

--- a/zozo-ios-engineer-codecheck/Data/HTTPMethod.swift
+++ b/zozo-ios-engineer-codecheck/Data/HTTPMethod.swift
@@ -1,0 +1,13 @@
+//
+//  HTTPMethod.swift
+//  zozo-ios-engineer-codecheck
+//
+//  Created by yuki.hamada on 2024/06/28.
+//
+
+import Foundation
+
+enum HTTPMethod: String {
+    case get = "GET"
+    case post = "POST"
+}

--- a/zozo-ios-engineer-codecheck/Data/Request/APIRequest.swift
+++ b/zozo-ios-engineer-codecheck/Data/Request/APIRequest.swift
@@ -1,0 +1,42 @@
+//
+//  APIRequest.swift
+//  zozo-ios-engineer-codecheck
+//
+//  Created by yuki.hamada on 2024/06/28.
+//
+
+import Foundation
+
+/// APIリクエスト時のパラメータ
+protocol APIRequest {
+    associatedtype Response: Decodable
+
+    var baseURL: URL { get }
+    var path: String { get }
+    var method: HTTPMethod { get }
+    var urlQueryItem: URLQueryItem { get }  // https://〜?hoge=1&hage=2 のクエリ
+    var body: Data? { get }
+}
+
+// MARK: - extension
+
+extension APIRequest {
+    func buildURLRequest() -> URLRequest {
+        let url = baseURL.appendingPathComponent(path)
+        var components = URLComponents(url: url, resolvingAgainstBaseURL: true)
+
+        var urlRequest = URLRequest(url: url)
+        urlRequest.httpMethod = method.rawValue
+
+        switch method {
+        case .get:
+            components?.queryItems = [urlQueryItem]
+            urlRequest.url = components?.url
+            return urlRequest
+        case .post:
+            urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")  // 動的にする必要がある場合は変更する
+            urlRequest.httpBody = body
+            return urlRequest
+        }
+    }
+}

--- a/zozo-ios-engineer-codecheck/Data/Request/APIRequestProtocol.swift
+++ b/zozo-ios-engineer-codecheck/Data/Request/APIRequestProtocol.swift
@@ -1,5 +1,5 @@
 //
-//  APIRequest.swift
+//  APIRequestProtocol.swift
 //  zozo-ios-engineer-codecheck
 //
 //  Created by yuki.hamada on 2024/06/28.
@@ -8,7 +8,7 @@
 import Foundation
 
 /// APIリクエスト時のパラメータ
-protocol APIRequest {
+protocol APIRequestProtocol {
     associatedtype Response: Decodable
 
     var baseURL: URL { get }
@@ -20,7 +20,7 @@ protocol APIRequest {
 
 // MARK: - extension
 
-extension APIRequest {
+extension APIRequestProtocol {
     func buildURLRequest() -> URLRequest {
         let url = baseURL.appendingPathComponent(path)
         var components = URLComponents(url: url, resolvingAgainstBaseURL: true)

--- a/zozo-ios-engineer-codecheck/Data/Request/SearchRepositoriesRequest.swift
+++ b/zozo-ios-engineer-codecheck/Data/Request/SearchRepositoriesRequest.swift
@@ -28,17 +28,9 @@ struct SearchRepositoriesRequest: APIRequestProtocol {
         return baseURL
     }
 
-    var path: String {
-        "/search/repositories"
-    }
-
-    var method: HTTPMethod {
-        .get
-    }
-
-    var body: Data? {
-        nil
-    }
+    var path: String = "/search/repositories"
+    var method: HTTPMethod = .get
+    var body: Data?
 
     var urlQueryItem: URLQueryItem {
         URLQueryItem(name: "q", value: searchWord)

--- a/zozo-ios-engineer-codecheck/Data/Request/SearchRepositoriesRequest.swift
+++ b/zozo-ios-engineer-codecheck/Data/Request/SearchRepositoriesRequest.swift
@@ -12,7 +12,7 @@ import Foundation
 /// ```
 /// let request = GIthubAPI.SearchRepository(searchWord: "swift")
 /// ```
-struct SearchRepositoriesRequest: APIRequest {
+struct SearchRepositoriesRequest: APIRequestProtocol {
     let searchWord: String
 
     init(searchWord: String) {
@@ -21,7 +21,7 @@ struct SearchRepositoriesRequest: APIRequest {
 
     typealias Response = SearchRepositoriesResponse
 
-    // MARK: - APIRequest
+    // MARK: - APIRequestProtocol
 
     var baseURL: URL {
         guard let baseURL = URL(string: "https://api.github.com") else { fatalError("error baseURL") }

--- a/zozo-ios-engineer-codecheck/Data/Request/SearchRepositoriesRequest.swift
+++ b/zozo-ios-engineer-codecheck/Data/Request/SearchRepositoriesRequest.swift
@@ -1,0 +1,46 @@
+//
+//  SearchRepositoriesRequest.swift
+//  zozo-ios-engineer-codecheck
+//
+//  Created by yuki.hamada on 2024/06/28.
+//
+
+import Foundation
+
+/// APIRequest に則ってRequestを作成
+///
+/// ```
+/// let request = GIthubAPI.SearchRepository(searchWord: "swift")
+/// ```
+struct SearchRepositoriesRequest: APIRequest {
+    let searchWord: String
+
+    init(searchWord: String) {
+        self.searchWord = searchWord
+    }
+
+    typealias Response = SearchRepositoriesResponse
+
+    // MARK: - APIRequest
+
+    var baseURL: URL {
+        guard let baseURL = URL(string: "https://api.github.com") else { fatalError("error baseURL") }
+        return baseURL
+    }
+
+    var path: String {
+        "/search/repositories"
+    }
+
+    var method: HTTPMethod {
+        .get
+    }
+
+    var body: Data? {
+        nil
+    }
+
+    var urlQueryItem: URLQueryItem {
+        URLQueryItem(name: "q", value: searchWord)
+    }
+}

--- a/zozo-ios-engineer-codecheck/Data/Response/SearchRepositoriesResponse.swift
+++ b/zozo-ios-engineer-codecheck/Data/Response/SearchRepositoriesResponse.swift
@@ -7,6 +7,10 @@
 
 struct SearchRepositoriesResponse: Decodable {
     var items: [GithubRepository]
+
+    init(items: [GithubRepository]) {
+        self.items = items
+    }
 }
 
 struct GithubRepository: Decodable {
@@ -20,9 +24,40 @@ struct GithubRepository: Decodable {
     var watchersCount: Int
     var createdAt: String
     var updatedAt: String
+
+    init(id: Int, name: String, fullName: String, htmlUrl: String, description: String, language: String? = nil, stargazersCount: Int, watchersCount: Int, createdAt: String, updatedAt: String) {
+        self.id = id
+        self.name = name
+        self.fullName = fullName
+        self.htmlUrl = htmlUrl
+        self.description = description
+        self.language = language
+        self.stargazersCount = stargazersCount
+        self.watchersCount = watchersCount
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+    }
 }
 
-struct Owner: Decodable {
-    var id: Int
-    var avatar_url: String
+// MARK: - for test
+
+extension SearchRepositoriesResponse {
+    /// テスト用
+    static func mock() -> [GithubRepository] {
+        return [
+            .init(
+                id: 0,
+                name: "",
+                fullName: "",
+                htmlUrl: "",
+                description: "",
+                language: "",
+                stargazersCount: 0,
+                watchersCount: 0,
+                createdAt: "",
+                updatedAt: ""
+            )
+        ]
+    }
 }
+

--- a/zozo-ios-engineer-codecheck/Data/Response/SearchRepositoriesResponse.swift
+++ b/zozo-ios-engineer-codecheck/Data/Response/SearchRepositoriesResponse.swift
@@ -1,0 +1,28 @@
+//
+//  SearchRepositoriesResponse.swift
+//  zozo-ios-engineer-codecheck
+//
+//  Created by yuki.hamada on 2024/06/28.
+//
+
+struct SearchRepositoriesResponse: Decodable {
+    var items: [GithubRepository]
+}
+
+struct GithubRepository: Decodable {
+    var id: Int
+    var name: String
+    var fullName: String
+    var htmlUrl: String
+    var description: String
+    var language: String?
+    var stargazersCount: Int
+    var watchersCount: Int
+    var createdAt: String
+    var updatedAt: String
+}
+
+struct Owner: Decodable {
+    var id: Int
+    var avatar_url: String
+}

--- a/zozo-ios-engineer-codecheck/Data/Response/SearchRepositoriesResponse.swift
+++ b/zozo-ios-engineer-codecheck/Data/Response/SearchRepositoriesResponse.swift
@@ -7,10 +7,6 @@
 
 struct SearchRepositoriesResponse: Decodable {
     var items: [GithubRepository]
-
-    init(items: [GithubRepository]) {
-        self.items = items
-    }
 }
 
 struct GithubRepository: Decodable {
@@ -24,19 +20,6 @@ struct GithubRepository: Decodable {
     var watchersCount: Int
     var createdAt: String
     var updatedAt: String
-
-    init(id: Int, name: String, fullName: String, htmlUrl: String, description: String, language: String? = nil, stargazersCount: Int, watchersCount: Int, createdAt: String, updatedAt: String) {
-        self.id = id
-        self.name = name
-        self.fullName = fullName
-        self.htmlUrl = htmlUrl
-        self.description = description
-        self.language = language
-        self.stargazersCount = stargazersCount
-        self.watchersCount = watchersCount
-        self.createdAt = createdAt
-        self.updatedAt = updatedAt
-    }
 }
 
 // MARK: - for test
@@ -44,7 +27,7 @@ struct GithubRepository: Decodable {
 extension SearchRepositoriesResponse {
     /// テスト用
     static func mock() -> [GithubRepository] {
-        return [
+        [
             .init(
                 id: 0,
                 name: "",
@@ -60,4 +43,3 @@ extension SearchRepositoriesResponse {
         ]
     }
 }
-


### PR DESCRIPTION
## 概要(一言で簡潔に)

APIClient を実装し、GithubAPI(search/repositories) からのレスポンス受け取りを可能に

## 詳細

APIClient の汎用性向上のため、以下項目に分けて実装しています。
- APIClient
- HTTPMethod
- HTTPError
- Request
- Response


GithubAPI(search/repositories) からレスポンスを受け取れること確認済みです

```APIClientViewController.swift
        Task {
            let apiRequest: SearchRepositoriesRequest = .init(searchWord: "swift")
            let apiClient: APIClient = .init()
            let response: Result<SearchRepositoriesResponse, HTTPError> = try await apiClient.request(apiRequest: apiRequest)
            switch response {
            case .success(let res):
                for item in res.items {
                    print(item.fullName)
                }
            case .failure(let error):
                print(error)
            }
        }
```

<details>
<summary> レスポンス </summary>

```hoge.txt
swiftlang/swift
SwiftyJSON/SwiftyJSON
ipader/SwiftGuide
openstack/swift
SwifterSwift/SwifterSwift
tensorflow/swift
realm/SwiftLint
iOS-Swift-Developers/Swift
airbnb/swift
jaguar07/Swift
ReactiveX/RxSwift
JakeLin/SwiftLanguageWeather
SwiftGen/SwiftGen
kodecocodes/swift-algorithm-club
malcommac/SwiftDate
matteocrippa/awesome-swift
SwiftKickMobile/SwiftMessages
facebookarchive/swift
Alamofire/Alamofire
nicklockwood/SwiftFormat
modelscope/swift
bizz84/SwiftyStoreKit
Juanpe/About-SwiftUI
SwiftGGTeam/the-swift-programming-language-in-chinese
swiftlang/swift-evolution
newlinedotco/FlappySwift
realm/realm-swift
Jinxiansen/SwiftUI
huri000/SwiftEntryKit
ivanvorobei/SwiftUI
```
</details>

## 確認してほしいこと

- 汎用的な設計になっているか
- エラーハンドリングの処理が適切か


## UI

なし


## 参考