### PR TITLE
リポジトリ一覧画面をブラッシュアップ

### DIFF
--- a/zozo-ios-engineer-codecheck.xcodeproj/project.pbxproj
+++ b/zozo-ios-engineer-codecheck.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		49111C072C25193A009D66F8 /* SearchRepositoryViewModelTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49111C062C25193A009D66F8 /* SearchRepositoryViewModelTest.swift */; };
 		49111C112C25193A009D66F8 /* zozo_ios_engineer_codecheckUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49111C102C25193A009D66F8 /* zozo_ios_engineer_codecheckUITests.swift */; };
 		49111C132C25193A009D66F8 /* zozo_ios_engineer_codecheckUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49111C122C25193A009D66F8 /* zozo_ios_engineer_codecheckUITestsLaunchTests.swift */; };
+		49AC1FFE2DC324A30026D2F4 /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = 49AC1FFD2DC324A30026D2F4 /* SnapKit */; };
 		49CD8F4E2C2A5F5700E78E9E /* SearchRepositoryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49CD8F4D2C2A5F5700E78E9E /* SearchRepositoryViewController.swift */; };
 		49CD8F502C2A719500E78E9E /* SearchRepositoryViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49CD8F4F2C2A719500E78E9E /* SearchRepositoryViewModel.swift */; };
 		49CD8F532C2E4BF100E78E9E /* HTTPMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49CD8F522C2E4BF100E78E9E /* HTTPMethod.swift */; };
@@ -22,8 +23,6 @@
 		49CD8F5B2C2E83CC00E78E9E /* SearchRepositoriesRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49CD8F5A2C2E83CC00E78E9E /* SearchRepositoriesRequest.swift */; };
 		49CD8F5D2C2E83FE00E78E9E /* SearchRepositoriesResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49CD8F5C2C2E83FE00E78E9E /* SearchRepositoriesResponse.swift */; };
 		49CD8F662C36A06B00E78E9E /* RepositoryViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49CD8F652C36A06B00E78E9E /* RepositoryViewCell.swift */; };
-		49CD8F692C36A95D00E78E9E /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = 49CD8F682C36A95D00E78E9E /* SnapKit */; };
-		49CD8F6B2C36A95D00E78E9E /* SnapKit-Dynamic in Frameworks */ = {isa = PBXBuildFile; productRef = 49CD8F6A2C36A95D00E78E9E /* SnapKit-Dynamic */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -70,8 +69,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				49CD8F692C36A95D00E78E9E /* SnapKit in Frameworks */,
-				49CD8F6B2C36A95D00E78E9E /* SnapKit-Dynamic in Frameworks */,
+				49AC1FFE2DC324A30026D2F4 /* SnapKit in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -207,8 +205,7 @@
 			);
 			name = "zozo-ios-engineer-codecheck";
 			packageProductDependencies = (
-				49CD8F682C36A95D00E78E9E /* SnapKit */,
-				49CD8F6A2C36A95D00E78E9E /* SnapKit-Dynamic */,
+				49AC1FFD2DC324A30026D2F4 /* SnapKit */,
 			);
 			productName = "zozo-ios-engineer-codecheck";
 			productReference = 49111BEC2C251938009D66F8 /* zozo-ios-engineer-codecheck.app */;
@@ -283,7 +280,7 @@
 			);
 			mainGroup = 49111BE32C251938009D66F8;
 			packageReferences = (
-				49CD8F672C36A95D00E78E9E /* XCRemoteSwiftPackageReference "SnapKit" */,
+				49AC1FFC2DC324A30026D2F4 /* XCRemoteSwiftPackageReference "SnapKit" */,
 			);
 			productRefGroup = 49111BED2C251938009D66F8 /* Products */;
 			projectDirPath = "";
@@ -537,7 +534,9 @@
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "hamadayuuki.zozo-ios-engineer-codecheck";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_COMPILATION_MODE = singlefile;
 				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_STRICT_CONCURRENCY = complete;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -566,7 +565,9 @@
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "hamadayuuki.zozo-ios-engineer-codecheck";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_COMPILATION_MODE = singlefile;
 				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_STRICT_CONCURRENCY = complete;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -690,7 +691,7 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
-		49CD8F672C36A95D00E78E9E /* XCRemoteSwiftPackageReference "SnapKit" */ = {
+		49AC1FFC2DC324A30026D2F4 /* XCRemoteSwiftPackageReference "SnapKit" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/SnapKit/SnapKit";
 			requirement = {
@@ -701,15 +702,10 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		49CD8F682C36A95D00E78E9E /* SnapKit */ = {
+		49AC1FFD2DC324A30026D2F4 /* SnapKit */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 49CD8F672C36A95D00E78E9E /* XCRemoteSwiftPackageReference "SnapKit" */;
+			package = 49AC1FFC2DC324A30026D2F4 /* XCRemoteSwiftPackageReference "SnapKit" */;
 			productName = SnapKit;
-		};
-		49CD8F6A2C36A95D00E78E9E /* SnapKit-Dynamic */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 49CD8F672C36A95D00E78E9E /* XCRemoteSwiftPackageReference "SnapKit" */;
-			productName = "SnapKit-Dynamic";
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/zozo-ios-engineer-codecheck.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/zozo-ios-engineer-codecheck.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,4 +1,5 @@
 {
+  "originHash" : "4cdad746817ac9ed37e44dbe90a2ff25fc018954899b7d513e41a4bfc70f065a",
   "pins" : [
     {
       "identity" : "snapkit",
@@ -10,5 +11,5 @@
       }
     }
   ],
-  "version" : 2
+  "version" : 3
 }

--- a/zozo-ios-engineer-codecheck/Data/Response/SearchRepositoriesResponse.swift
+++ b/zozo-ios-engineer-codecheck/Data/Response/SearchRepositoriesResponse.swift
@@ -16,8 +16,8 @@ struct GithubRepository: Decodable, Hashable {
     var name: String
     var fullName: String
     var htmlUrl: String
-    var description: String
-    var language: String
+    var description: String?
+    var language: String?
     var stargazersCount: Int
     var watchersCount: Int
     var createdAt: String

--- a/zozo-ios-engineer-codecheck/Feature/SearchRepository/RepositoryViewCell.swift
+++ b/zozo-ios-engineer-codecheck/Feature/SearchRepository/RepositoryViewCell.swift
@@ -74,7 +74,7 @@ class RepositoryViewCell: UICollectionViewCell {
         contentView.addSubview(stackView)
         stackView.snp.makeConstraints {
             $0.horizontalEdges.equalToSuperview()
-            $0.verticalEdges.equalToSuperview().inset(space)
+            $0.verticalEdges.equalToSuperview().inset(space).priority(.low)   // collectionViewの動的なアイテムサイズ(.estimated(1))が原因で Auto Layout の競合が発生したため、垂直方向の制約の優先度を下げて (priority(.low)) 、競合を解決
         }
 
         contentView.addSubview(divider)

--- a/zozo-ios-engineer-codecheck/Feature/SearchRepository/RepositoryViewCell.swift
+++ b/zozo-ios-engineer-codecheck/Feature/SearchRepository/RepositoryViewCell.swift
@@ -23,26 +23,28 @@ class RepositoryViewCell: UICollectionViewCell {
     // TODO: - Coreフォルダを作りUILabel(やフォントサイズなど)を共通化する
     private let repoName: UILabel = {
         let label: UILabel = .init()
-        label.font = .systemFont(ofSize: 18, weight: .regular)
+        label.font = .systemFont(ofSize: 16, weight: .bold)
         return label
     }()
 
     private let repoDescription: UILabel = {
         let label: UILabel = .init()
-        label.font = .systemFont(ofSize: 18, weight: .regular)
+        label.font = .systemFont(ofSize: 14, weight: .regular)
         label.numberOfLines = 0   // 高さ動的化のため
         return label
     }()
 
     private let stargazersCount: UILabel = {
         let label: UILabel = .init()
-        label.font = .systemFont(ofSize: 18, weight: .regular)
+        label.font = .systemFont(ofSize: 14, weight: .regular)
+        label.textColor = .gray
         return label
     }()
 
     private let language: UILabel = {
         let label: UILabel = .init()
-        label.font = .systemFont(ofSize: 18, weight: .regular)
+        label.font = .systemFont(ofSize: 14, weight: .regular)
+        label.textColor = .gray
         return label
     }()
 
@@ -66,14 +68,24 @@ class RepositoryViewCell: UICollectionViewCell {
             $0.width.equalToSuperview()
         }
 
-        addSubview(stargazersCount)
-        stargazersCount.snp.makeConstraints {
+        let horizontalViewStack: UIStackView = {
+            let viewStack = UIStackView(arrangedSubviews: [stargazersCount, language])
+            viewStack.axis = .horizontal
+            viewStack.spacing = 12
+            return viewStack
+        }()
+        addSubview(horizontalViewStack)
+        horizontalViewStack.snp.makeConstraints {
             $0.top.equalTo(repoDescription.snp.bottom).offset(12)
         }
 
-        addSubview(language)
-        language.snp.makeConstraints {
-            $0.top.equalTo(stargazersCount.snp.bottom).offset(12)
+        let divider = UIView()
+        divider.backgroundColor = .lightGray
+        addSubview(divider)
+        divider.snp.makeConstraints {
+            $0.bottom.equalToSuperview().offset(-12)   // TODO: - 高さ動的化の時offsetを使わない実装, 他要素の高さによって他要素と重なって表示される
+            $0.height.equalTo(1)
+            $0.width.equalToSuperview()
         }
     }
 
@@ -84,7 +96,7 @@ class RepositoryViewCell: UICollectionViewCell {
     func setState(state: State) {
         repoName.text = state.repoName
         repoDescription.text = state.repoDescription
-        stargazersCount.text = "\(state.stargazersCount)"
-        language.text = state.language
+        stargazersCount.text = "⭐︎ \(state.stargazersCount)"
+        language.text = "✏︎ \(state.language)"
     }
 }

--- a/zozo-ios-engineer-codecheck/Feature/SearchRepository/RepositoryViewCell.swift
+++ b/zozo-ios-engineer-codecheck/Feature/SearchRepository/RepositoryViewCell.swift
@@ -38,6 +38,7 @@ class RepositoryViewCell: UICollectionViewCell {
         let label: UILabel = .init()
         label.font = .systemFont(ofSize: 14, weight: .regular)
         label.textColor = .gray
+        label.setContentHuggingPriority(.required, for: .horizontal)   // 領域拡大によるレイアウト崩れ防止
         return label
     }()
 
@@ -45,7 +46,14 @@ class RepositoryViewCell: UICollectionViewCell {
         let label: UILabel = .init()
         label.font = .systemFont(ofSize: 14, weight: .regular)
         label.textColor = .gray
+        label.setContentCompressionResistancePriority(.required, for: .horizontal)   // 領域縮小によるレイアウト崩れ防止
         return label
+    }()
+
+    private let divider: UIView = {
+        let divider = UIView()
+        divider.backgroundColor = .systemGray5
+        return divider
     }()
 
     override init(frame: CGRect) {
@@ -55,37 +63,25 @@ class RepositoryViewCell: UICollectionViewCell {
     }
 
     private func configureViewCell() {
-        addSubview(repoName)
-        repoName.snp.makeConstraints {
-            $0.top.equalToSuperview()
-            $0.width.equalToSuperview()   // 文字を折り返して表示するため
+        let space: CGFloat = 12
+        let horizontalStackView = UIStackView(arrangedSubviews: [stargazersCount, language])
+        horizontalStackView.axis = .horizontal
+        horizontalStackView.spacing = space
+
+        let stackView = UIStackView(arrangedSubviews: [repoName, repoDescription, horizontalStackView])
+        stackView.axis = .vertical
+        stackView.spacing = space
+        contentView.addSubview(stackView)
+        stackView.snp.makeConstraints {
+            $0.horizontalEdges.equalToSuperview()
+            $0.verticalEdges.equalToSuperview().inset(space)
         }
 
-        addSubview(repoDescription)
-        repoDescription.sizeToFit()
-        repoDescription.snp.makeConstraints {
-            $0.top.equalTo(repoName.snp.bottom).offset(12)
-            $0.width.equalToSuperview()
-        }
-
-        let horizontalViewStack: UIStackView = {
-            let viewStack = UIStackView(arrangedSubviews: [stargazersCount, language])
-            viewStack.axis = .horizontal
-            viewStack.spacing = 12
-            return viewStack
-        }()
-        addSubview(horizontalViewStack)
-        horizontalViewStack.snp.makeConstraints {
-            $0.top.equalTo(repoDescription.snp.bottom).offset(12)
-        }
-
-        let divider = UIView()
-        divider.backgroundColor = .lightGray
-        addSubview(divider)
+        contentView.addSubview(divider)
         divider.snp.makeConstraints {
-            $0.bottom.equalToSuperview().offset(-12)   // TODO: - 高さ動的化の時offsetを使わない実装, 他要素の高さによって他要素と重なって表示される
+            $0.top.equalTo(stackView.snp.bottom).offset(space)   // stackViewの上下に余白を12とっているためoffsetで表示位置ずらしても問題ない
+            $0.horizontalEdges.equalToSuperview()
             $0.height.equalTo(1)
-            $0.width.equalToSuperview()
         }
     }
 

--- a/zozo-ios-engineer-codecheck/Feature/SearchRepository/SearchRepositoryViewController.swift
+++ b/zozo-ios-engineer-codecheck/Feature/SearchRepository/SearchRepositoryViewController.swift
@@ -44,10 +44,6 @@ class SearchRepositoryViewController: UIViewController {
         configureDataSource()
         configureViews()
         setupBinding()
-
-        Task {
-            try await viewModel.viewDidLoad(searchWord: "Swift")
-        }
     }
 
     // MARK: - UI
@@ -107,9 +103,11 @@ class SearchRepositoryViewController: UIViewController {
             .sink { [weak self] state in
                 guard let self else { return }
                 switch state {
-                case .initial, .loading:
+                case .initial:
+                    updateDataSource(repositories: [])
+                case .loading:
+                    updateDataSource(repositories: [])
                     // TODO: - ローディング画面
-                    break
                 case .success(let response):
                     let repositories = response.items
                     updateDataSource(repositories: repositories)
@@ -158,6 +156,11 @@ extension SearchRepositoryViewController: UISearchBarDelegate {
 
     // エンターキーで検索
     func searchBarSearchButtonClicked(_ searchBar: UISearchBar) {
+        guard let searchWord = searchBar.text else { return }
+        Task {
+            try await viewModel.searchButtonTapped(searchWord: searchWord)
+        }
+
         searchBar.resignFirstResponder()
         searchBar.setShowsCancelButton(false, animated: true)
     }

--- a/zozo-ios-engineer-codecheck/Feature/SearchRepository/SearchRepositoryViewController.swift
+++ b/zozo-ios-engineer-codecheck/Feature/SearchRepository/SearchRepositoryViewController.swift
@@ -10,6 +10,7 @@ import Combine
 import SnapKit
 
 class SearchRepositoryViewController: UIViewController {
+
     /// SearchRepositoryViewController の DiffableDataSource 用に定義
     private enum SectionType {
         case repositories
@@ -40,7 +41,7 @@ class SearchRepositoryViewController: UIViewController {
         super.viewDidLoad()
 
         view.backgroundColor = .white
-        configDataSource()
+        configureDataSource()
         configureViews()
         setupBinding()
 
@@ -49,7 +50,7 @@ class SearchRepositoryViewController: UIViewController {
         }
     }
 
-    // MARK: - UI compornents
+    // MARK: - UI
 
     private lazy var collectionView: UICollectionView = {
         let collectionView: UICollectionView = .init(frame: .zero, collectionViewLayout: .init())
@@ -58,10 +59,7 @@ class SearchRepositoryViewController: UIViewController {
         return collectionView
     }()
 
-    // MARK: - function
-
     private func configureViews() {
-        // CollectionView
         let layout = UICollectionViewCompositionalLayout { (_, _) -> NSCollectionLayoutSection? in
             let spacing: CGFloat = 12
             let width = self.view.bounds.width - (spacing * 2)
@@ -80,18 +78,7 @@ class SearchRepositoryViewController: UIViewController {
         view.addSubview(collectionView)
     }
 
-    private func configureDataSource() {
-        var snapshot = NSDiffableDataSourceSnapshot<SectionType, GithubRepository>()
-        snapshot.appendSections([.repositories])
-        dataSource.apply(snapshot, animatingDifferences: true)
-    }
-
-    /// GitHubAPIから正常にレスポンスを受け取れ場合レポジトリ一覧のデータ更新する
-    private func updateDataSource(repositories: [GithubRepository]) {
-        var snapShot = dataSource.snapshot()
-        snapShot.appendItems(repositories, toSection: .repositories)
-        dataSource.apply(snapShot, animatingDifferences: true)
-    }
+    // MARK: - function
 
     private func setupBinding() {
         viewModel.$state
@@ -112,4 +99,24 @@ class SearchRepositoryViewController: UIViewController {
             }
             .store(in: &cancellables)
     }
+
+}
+
+// MARK: - UICollectionView
+
+extension SearchRepositoryViewController {
+
+    private func configureDataSource() {
+        var snapshot = NSDiffableDataSourceSnapshot<SectionType, GithubRepository>()
+        snapshot.appendSections([.repositories])
+        dataSource.apply(snapshot, animatingDifferences: true)
+    }
+
+    /// GitHubAPIから正常にレスポンスを受け取れ場合レポジトリ一覧のデータ更新する
+    private func updateDataSource(repositories: [GithubRepository]) {
+        var snapShot = dataSource.snapshot()
+        snapShot.appendItems(repositories, toSection: .repositories)
+        dataSource.apply(snapShot, animatingDifferences: true)
+    }
+
 }

--- a/zozo-ios-engineer-codecheck/Feature/SearchRepository/SearchRepositoryViewController.swift
+++ b/zozo-ios-engineer-codecheck/Feature/SearchRepository/SearchRepositoryViewController.swift
@@ -59,7 +59,20 @@ class SearchRepositoryViewController: UIViewController {
         return collectionView
     }()
 
+    private lazy var searchBar: UISearchBar = {
+        let searchBar: UISearchBar = .init()
+        searchBar.delegate = self
+        return searchBar
+    }()
+
     private func configureViews() {
+        view.addSubview(searchBar)
+        searchBar.snp.makeConstraints {
+            $0.top.equalTo(view.safeAreaLayoutGuide.snp.top)
+            $0.left.equalToSuperview()
+            $0.right.equalToSuperview()
+        }
+
         let layout = UICollectionViewCompositionalLayout { (_, _) -> NSCollectionLayoutSection? in
             let spacing: CGFloat = 12
             let width = self.view.bounds.width - (spacing * 2)
@@ -76,6 +89,12 @@ class SearchRepositoryViewController: UIViewController {
         }
         collectionView.collectionViewLayout = layout
         view.addSubview(collectionView)
+        collectionView.snp.makeConstraints {
+            $0.top.equalTo(searchBar.snp.bottom)
+            $0.bottom.equalTo(view.safeAreaLayoutGuide.snp.bottom)
+            $0.left.equalToSuperview()
+            $0.right.equalToSuperview()
+        }
     }
 
     // MARK: - function
@@ -120,3 +139,7 @@ extension SearchRepositoryViewController {
     }
 
 }
+
+// MARK: - UISearchBar
+
+extension SearchRepositoryViewController: UISearchBarDelegate {}

--- a/zozo-ios-engineer-codecheck/Feature/SearchRepository/SearchRepositoryViewController.swift
+++ b/zozo-ios-engineer-codecheck/Feature/SearchRepository/SearchRepositoryViewController.swift
@@ -78,7 +78,7 @@ class SearchRepositoryViewController: UIViewController {
             let itemSize = NSCollectionLayoutSize(widthDimension: .absolute(width), heightDimension: .fractionalHeight(1))
             let item = NSCollectionLayoutItem(layoutSize: itemSize)
 
-            let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1), heightDimension: .absolute(200))   // TODO: - 高さを動的化
+            let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1), heightDimension: .absolute(150))   // TODO: - 高さを動的化
             let group = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize, subitems: [item])
 
             let section = NSCollectionLayoutSection(group: group)

--- a/zozo-ios-engineer-codecheck/Feature/SearchRepository/SearchRepositoryViewController.swift
+++ b/zozo-ios-engineer-codecheck/Feature/SearchRepository/SearchRepositoryViewController.swift
@@ -72,17 +72,19 @@ class SearchRepositoryViewController: UIViewController {
         }
 
         let layout = UICollectionViewCompositionalLayout { (_, _) -> NSCollectionLayoutSection? in
-            let spacing: CGFloat = 12
-            let width = self.view.bounds.width - (spacing * 2)
+            let space: CGFloat = 12
+            let width = self.view.bounds.width - (space * 2)
 
-            let itemSize = NSCollectionLayoutSize(widthDimension: .absolute(width), heightDimension: .fractionalHeight(1))
+            /// アイテムサイズ動的化のため
+            let heightDimension: NSCollectionLayoutDimension = .estimated(1)
+            let itemSize = NSCollectionLayoutSize(widthDimension: .absolute(width), heightDimension: heightDimension)
             let item = NSCollectionLayoutItem(layoutSize: itemSize)
 
-            let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1), heightDimension: .absolute(150))   // TODO: - 高さを動的化
+            let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1), heightDimension: heightDimension)
             let group = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize, subitems: [item])
 
             let section = NSCollectionLayoutSection(group: group)
-            section.contentInsets = .init(top: spacing, leading: spacing, bottom: spacing, trailing: spacing)
+            section.contentInsets = .init(top: space, leading: space, bottom: space, trailing: space)
             return section
         }
         collectionView.collectionViewLayout = layout

--- a/zozo-ios-engineer-codecheck/Feature/SearchRepository/SearchRepositoryViewController.swift
+++ b/zozo-ios-engineer-codecheck/Feature/SearchRepository/SearchRepositoryViewController.swift
@@ -61,6 +61,8 @@ class SearchRepositoryViewController: UIViewController {
 
     private lazy var searchBar: UISearchBar = {
         let searchBar: UISearchBar = .init()
+        searchBar.backgroundImage = .init()   // 枠線削除
+        searchBar.showsCancelButton = true
         searchBar.delegate = self
         return searchBar
     }()
@@ -142,4 +144,21 @@ extension SearchRepositoryViewController {
 
 // MARK: - UISearchBar
 
-extension SearchRepositoryViewController: UISearchBarDelegate {}
+extension SearchRepositoryViewController: UISearchBarDelegate {
+    // 検索バー編集開始時にキャンセルボタン有効化
+    func searchBarTextDidBeginEditing(_ searchBar: UISearchBar) {
+        searchBar.setShowsCancelButton(true, animated: true)
+    }
+
+    // キャンセルボタンでキャセルボタン非表示
+    func searchBarCancelButtonClicked(_ searchBar: UISearchBar) {
+        searchBar.resignFirstResponder()
+        searchBar.setShowsCancelButton(false, animated: true)
+    }
+
+    // エンターキーで検索
+    func searchBarSearchButtonClicked(_ searchBar: UISearchBar) {
+        searchBar.resignFirstResponder()
+        searchBar.setShowsCancelButton(false, animated: true)
+    }
+}

--- a/zozo-ios-engineer-codecheck/Feature/SearchRepository/SearchRepositoryViewController.swift
+++ b/zozo-ios-engineer-codecheck/Feature/SearchRepository/SearchRepositoryViewController.swift
@@ -20,9 +20,9 @@ class SearchRepositoryViewController: UIViewController {
         let repositoryCell = UICollectionView.CellRegistration<RepositoryViewCell, GithubRepository>() { cell, _, repository in
             let cellState: RepositoryViewCell.State = .init(
                 repoName: repository.fullName,
-                repoDescription: repository.description,
+                repoDescription: repository.description ?? "",
                 stargazersCount: repository.stargazersCount,
-                language: repository.language
+                language: repository.language ?? ""
             )
             cell.setState(state: cellState)
         }
@@ -104,9 +104,9 @@ class SearchRepositoryViewController: UIViewController {
                 guard let self else { return }
                 switch state {
                 case .initial:
-                    updateDataSource(repositories: [])
+                    resetDataSource()
                 case .loading:
-                    updateDataSource(repositories: [])
+                    break
                     // TODO: - ローディング画面
                 case .success(let response):
                     let repositories = response.items
@@ -129,6 +129,13 @@ extension SearchRepositoryViewController {
         var snapshot = NSDiffableDataSourceSnapshot<SectionType, GithubRepository>()
         snapshot.appendSections([.repositories])
         dataSource.apply(snapshot, animatingDifferences: true)
+    }
+
+    private func resetDataSource() {
+        var snapShot = dataSource.snapshot()
+        snapShot.deleteAllItems()
+        snapShot.appendSections([.repositories])
+        dataSource.apply(snapShot, animatingDifferences: true)
     }
 
     /// GitHubAPIから正常にレスポンスを受け取れ場合レポジトリ一覧のデータ更新する

--- a/zozo-ios-engineer-codecheck/Feature/SearchRepository/SearchRepositoryViewModel.swift
+++ b/zozo-ios-engineer-codecheck/Feature/SearchRepository/SearchRepositoryViewModel.swift
@@ -11,7 +11,7 @@ import Foundation
 
 // アクセスレベルは他のファイルから呼び出せるように設定
 protocol SearchRepositoryViewModelInput {
-    func viewDidLoad(searchWord: String) async throws
+    func searchButtonTapped(searchWord: String) async throws
 }
 
 protocol SearchRepositoryViewModelOutput {
@@ -43,7 +43,7 @@ final class SearchRepositoryViewModel: SearchRepositoryViewModelProtocol {
     // MARK: - inputs
 
     @MainActor
-    func viewDidLoad(searchWord: String) async throws {
+    func searchButtonTapped(searchWord: String) async throws {
         state = .loading
         let searchRepoRequest: SearchRepositoriesRequest = .init(searchWord: searchWord)
         do {

--- a/zozo-ios-engineer-codecheck/Feature/SearchRepository/SearchRepositoryViewModel.swift
+++ b/zozo-ios-engineer-codecheck/Feature/SearchRepository/SearchRepositoryViewModel.swift
@@ -44,6 +44,7 @@ final class SearchRepositoryViewModel: SearchRepositoryViewModelProtocol {
 
     @MainActor
     func searchButtonTapped(searchWord: String) async throws {
+        state = .initial
         state = .loading
         let searchRepoRequest: SearchRepositoriesRequest = .init(searchWord: searchWord)
         do {


### PR DESCRIPTION
## 概要(簡潔に一言で)

- [SnapKit](https://github.com/SnapKit/SnapKit)用いてリポジトリ一覧画面のUIをブラッシュアップしました

## 詳細

取り組んだことは以下の2つです
- [SnapKit](https://github.com/SnapKit/SnapKit)用いたレイアウト修正
- 検索欄を追加
- 検索欄に入力した文字をもとにしてレポジトリ一覧を更新する


## 確認してほしいこと

検索文字の指定→リポジトリ一覧の更新 のデータフローは適切か


## UI

| リポジトリ一覧 |
| --- |
| <img width = 300 src = "https://github.com/user-attachments/assets/be29965a-db1a-444e-ad45-b59f3430ed48"> |



## 参考