### PR TITLE
Step3-1 画面遷移を実装

### DIFF
--- a/zozo-ios-engineer-codecheck.xcodeproj/project.pbxproj
+++ b/zozo-ios-engineer-codecheck.xcodeproj/project.pbxproj
@@ -19,6 +19,8 @@
 		4934685B2DCB45BC001B6A95 /* RepositoryDetailRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4934685A2DCB45BC001B6A95 /* RepositoryDetailRequest.swift */; };
 		4934685D2DCB48E5001B6A95 /* RepositoryDetailResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4934685C2DCB48E5001B6A95 /* RepositoryDetailResponse.swift */; };
 		493489FA2DD7466E001B6A95 /* String+extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 493489F92DD74666001B6A95 /* String+extension.swift */; };
+		4984406C2DDDA98400AFB21A /* WireframeProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4984406B2DDDA98400AFB21A /* WireframeProtocol.swift */; };
+		498440702DDDAAF900AFB21A /* SearchRepositoryWireframe.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4984406F2DDDAAF900AFB21A /* SearchRepositoryWireframe.swift */; };
 		49AC1FFE2DC324A30026D2F4 /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = 49AC1FFD2DC324A30026D2F4 /* SnapKit */; };
 		49CD8F4E2C2A5F5700E78E9E /* SearchRepositoryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49CD8F4D2C2A5F5700E78E9E /* SearchRepositoryViewController.swift */; };
 		49CD8F502C2A719500E78E9E /* SearchRepositoryViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49CD8F4F2C2A719500E78E9E /* SearchRepositoryViewModel.swift */; };
@@ -64,6 +66,8 @@
 		4934685A2DCB45BC001B6A95 /* RepositoryDetailRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepositoryDetailRequest.swift; sourceTree = "<group>"; };
 		4934685C2DCB48E5001B6A95 /* RepositoryDetailResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepositoryDetailResponse.swift; sourceTree = "<group>"; };
 		493489F92DD74666001B6A95 /* String+extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+extension.swift"; sourceTree = "<group>"; };
+		4984406B2DDDA98400AFB21A /* WireframeProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WireframeProtocol.swift; sourceTree = "<group>"; };
+		4984406F2DDDAAF900AFB21A /* SearchRepositoryWireframe.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchRepositoryWireframe.swift; sourceTree = "<group>"; };
 		49CD8F4D2C2A5F5700E78E9E /* SearchRepositoryViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchRepositoryViewController.swift; sourceTree = "<group>"; };
 		49CD8F4F2C2A719500E78E9E /* SearchRepositoryViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchRepositoryViewModel.swift; sourceTree = "<group>"; };
 		49CD8F522C2E4BF100E78E9E /* HTTPMethod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPMethod.swift; sourceTree = "<group>"; };
@@ -125,6 +129,7 @@
 		49111BEE2C251938009D66F8 /* zozo-ios-engineer-codecheck */ = {
 			isa = PBXGroup;
 			children = (
+				4984406A2DDDA97500AFB21A /* Core */,
 				493489F82DD74643001B6A95 /* Extension */,
 				49111BEF2C251938009D66F8 /* AppDelegate.swift */,
 				49111BF12C251938009D66F8 /* SceneDelegate.swift */,
@@ -168,6 +173,14 @@
 				493489F92DD74666001B6A95 /* String+extension.swift */,
 			);
 			path = Extension;
+			sourceTree = "<group>";
+		};
+		4984406A2DDDA97500AFB21A /* Core */ = {
+			isa = PBXGroup;
+			children = (
+				4984406B2DDDA98400AFB21A /* WireframeProtocol.swift */,
+			);
+			path = Core;
 			sourceTree = "<group>";
 		};
 		49CD8F512C2E4B4300E78E9E /* Data */ = {
@@ -216,6 +229,7 @@
 				49CD8F4F2C2A719500E78E9E /* SearchRepositoryViewModel.swift */,
 				49CD8F4D2C2A5F5700E78E9E /* SearchRepositoryViewController.swift */,
 				49CD8F652C36A06B00E78E9E /* RepositoryViewCell.swift */,
+				4984406F2DDDAAF900AFB21A /* SearchRepositoryWireframe.swift */,
 			);
 			path = SearchRepository;
 			sourceTree = "<group>";
@@ -384,9 +398,11 @@
 				49CD8F502C2A719500E78E9E /* SearchRepositoryViewModel.swift in Sources */,
 				493468532DCB31C6001B6A95 /* RepositoryDetailViewController.swift in Sources */,
 				493468592DCB42AB001B6A95 /* RepositoryDetailViewModel.swift in Sources */,
+				4984406C2DDDA98400AFB21A /* WireframeProtocol.swift in Sources */,
 				49CD8F5B2C2E83CC00E78E9E /* SearchRepositoriesRequest.swift in Sources */,
 				49CD8F572C2E573700E78E9E /* APIClient.swift in Sources */,
 				49CD8F592C2E581500E78E9E /* HTTPError.swift in Sources */,
+				498440702DDDAAF900AFB21A /* SearchRepositoryWireframe.swift in Sources */,
 				49CD8F5D2C2E83FE00E78E9E /* SearchRepositoriesResponse.swift in Sources */,
 				49CD8F4E2C2A5F5700E78E9E /* SearchRepositoryViewController.swift in Sources */,
 				49CD8F662C36A06B00E78E9E /* RepositoryViewCell.swift in Sources */,

--- a/zozo-ios-engineer-codecheck/Core/WireframeProtocol.swift
+++ b/zozo-ios-engineer-codecheck/Core/WireframeProtocol.swift
@@ -10,8 +10,10 @@ import UIKit
 // 各画面ごとに wireframe を実装して画面遷移する
 @MainActor
 protocol WireframeProtocol {
+    associatedtype Input
+
     /// 遷移先画面を構築する
-    func nextVC() -> UIViewController
+    func nextVC(_ input: Input) -> UIViewController
     /// 画面遷移を担当
     func translation(navigationController: UINavigationController?, nextVC: UIViewController)
 }

--- a/zozo-ios-engineer-codecheck/Core/WireframeProtocol.swift
+++ b/zozo-ios-engineer-codecheck/Core/WireframeProtocol.swift
@@ -1,0 +1,17 @@
+//
+//  WireframeProtocol.swift
+//  zozo-ios-engineer-codecheck
+//
+//  Created by yuki.hamada on 2025/05/21.
+//
+
+import UIKit
+
+// 各画面ごとに wireframe を実装して画面遷移する
+@MainActor
+protocol WireframeProtocol {
+    /// 遷移先画面を構築する
+    func nextVC() -> UIViewController
+    /// 画面遷移を担当
+    func translation(navigationController: UINavigationController?, nextVC: UIViewController)
+}

--- a/zozo-ios-engineer-codecheck/Data/Response/SearchRepositoriesResponse.swift
+++ b/zozo-ios-engineer-codecheck/Data/Response/SearchRepositoriesResponse.swift
@@ -15,6 +15,7 @@ struct GithubRepository: Decodable, Hashable {
     var id: Int
     var name: String
     var fullName: String
+    var owner: Owner
     var htmlUrl: String
     var description: String?
     var language: String?
@@ -22,6 +23,11 @@ struct GithubRepository: Decodable, Hashable {
     var watchersCount: Int
     var createdAt: String
     var updatedAt: String
+
+    struct Owner: Decodable, Hashable {
+        var id: Int
+        var login: String   // owner name
+    }
 }
 
 // MARK: - for test
@@ -32,7 +38,7 @@ extension SearchRepositoriesResponse {
     /// length で受け取った長さ分のリストを返却
     static func stub(length: Int = 1) -> Self {
         .init(items: Array(repeating: (), count: length).enumerated().map { index, _ -> GithubRepository in
-            GithubRepository(id: index, name: "hoge", fullName: "hoge/hoge", htmlUrl: "", description: "hoge hoge hoge", language: "swift", stargazersCount: 100, watchersCount: 100, createdAt: "", updatedAt: "")
+            GithubRepository(id: index, name: "hoge", fullName: "hoge/hoge", owner: .init(id: 0, login: "owner"), htmlUrl: "", description: "hoge hoge hoge", language: "swift", stargazersCount: 100, watchersCount: 100, createdAt: "", updatedAt: "")
         })
     }
 }

--- a/zozo-ios-engineer-codecheck/Feature/SearchRepository/SearchRepositoryViewController.swift
+++ b/zozo-ios-engineer-codecheck/Feature/SearchRepository/SearchRepositoryViewController.swift
@@ -39,6 +39,7 @@ class SearchRepositoryViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        collectionView.delegate = self   // UICollectionViewDelegate
 
         view.backgroundColor = .white
         configureDataSource()
@@ -147,6 +148,15 @@ extension SearchRepositoryViewController {
         dataSource.apply(snapShot, animatingDifferences: true)
     }
 
+}
+
+extension SearchRepositoryViewController: UICollectionViewDelegate {
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        guard let repository = dataSource.itemIdentifier(for: indexPath) else { return }
+        let wireframe: SearchRepositoryWireframe = .init(owner: repository.owner.login, repo: repository.name)
+        let nextVC = wireframe.nextVC()
+        wireframe.translation(navigationController: navigationController, nextVC: nextVC)
+    }
 }
 
 // MARK: - UISearchBar

--- a/zozo-ios-engineer-codecheck/Feature/SearchRepository/SearchRepositoryViewController.swift
+++ b/zozo-ios-engineer-codecheck/Feature/SearchRepository/SearchRepositoryViewController.swift
@@ -153,8 +153,8 @@ extension SearchRepositoryViewController {
 extension SearchRepositoryViewController: UICollectionViewDelegate {
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         guard let repository = dataSource.itemIdentifier(for: indexPath) else { return }
-        let wireframe: SearchRepositoryWireframe = .init(owner: repository.owner.login, repo: repository.name)
-        let nextVC = wireframe.nextVC()
+        let wireframe: SearchRepositoryWireframe = .init()
+        let nextVC = wireframe.nextVC(SearchRepositoryWireframe.Input(owner: repository.owner.login, repo: repository.name))
         wireframe.translation(navigationController: navigationController, nextVC: nextVC)
     }
 }

--- a/zozo-ios-engineer-codecheck/Feature/SearchRepository/SearchRepositoryWireframe.swift
+++ b/zozo-ios-engineer-codecheck/Feature/SearchRepository/SearchRepositoryWireframe.swift
@@ -9,16 +9,11 @@ import UIKit
 
 @MainActor
 final class SearchRepositoryWireframe: WireframeProtocol {
-    let owner: String
-    let repo: String
-    init(owner: String, repo: String) {
-        self.owner = owner
-        self.repo = repo
-    }
+    typealias Input = (owner: String, repo: String)
 
-    func nextVC() -> UIViewController {
+    func nextVC(_ input: Input) -> UIViewController {
         let apiClient: APIClient = .init()
-        let repositoryDetailViewModel: RepositoryDetailViewModel = .init(owner: owner, repo: repo, apiClient: apiClient)
+        let repositoryDetailViewModel: RepositoryDetailViewModel = .init(owner: input.owner, repo: input.repo, apiClient: apiClient)
         let repositoryDetailViewController = RepositoryDetailViewController(viewModel: repositoryDetailViewModel)
         return repositoryDetailViewController
     }

--- a/zozo-ios-engineer-codecheck/Feature/SearchRepository/SearchRepositoryWireframe.swift
+++ b/zozo-ios-engineer-codecheck/Feature/SearchRepository/SearchRepositoryWireframe.swift
@@ -1,0 +1,29 @@
+//
+//  SearchRepositoryWireframe.swift
+//  zozo-ios-engineer-codecheck
+//
+//  Created by yuki.hamada on 2025/05/21.
+//
+
+import UIKit
+
+@MainActor
+final class SearchRepositoryWireframe: WireframeProtocol {
+    let owner: String
+    let repo: String
+    init(owner: String, repo: String) {
+        self.owner = owner
+        self.repo = repo
+    }
+
+    func nextVC() -> UIViewController {
+        let apiClient: APIClient = .init()
+        let repositoryDetailViewModel: RepositoryDetailViewModel = .init(owner: owner, repo: repo, apiClient: apiClient)
+        let repositoryDetailViewController = RepositoryDetailViewController(viewModel: repositoryDetailViewModel)
+        return repositoryDetailViewController
+    }
+
+    func translation(navigationController: UINavigationController?, nextVC: UIViewController) {
+        navigationController?.pushViewController(nextVC, animated: true)
+    }
+}

--- a/zozo-ios-engineer-codecheck/SceneDelegate.swift
+++ b/zozo-ios-engineer-codecheck/SceneDelegate.swift
@@ -15,7 +15,9 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         guard let windowScene = (scene as? UIWindowScene) else { return }
 
         let window = UIWindow(windowScene: windowScene)
-        window.rootViewController = RepositoryDetailViewController(viewModel: .init(owner: "swiftlang", repo: "swift", apiClient: APIClient()))
+        let searchRepositoryViewController = SearchRepositoryViewController()
+        let navigationController = UINavigationController(rootViewController: searchRepositoryViewController)
+        window.rootViewController = navigationController
         window.makeKeyAndVisible()
         self.window = window
     }


### PR DESCRIPTION
## 概要（一言で簡潔に）

Wireframe を採用して画面遷移を実装しました

## 詳細

- 画面遷移のロジックを Wireframe へ移行しています
     - Wireframeの責務 : 遷移先画面を構築する + 画面遷移
- リポジトリ詳細画面に必要なデータを GitHub API から取得できるように、レスポンス定義を若干変更しました
     - owner 情報を追加

## スクリーンショット（あれば）

| リポジトリ一覧 -> リポジトリ詳細 |
| --- |
| <img width = 300 src = "https://github.com/user-attachments/assets/9eeb9d12-7c67-4fd7-abac-c1aa55017df3"> |


