### PR TITLE
Step4 リポジトリのスター解除を実装

### DIFF
--- a/zozo-ios-engineer-codecheck.xcodeproj/project.pbxproj
+++ b/zozo-ios-engineer-codecheck.xcodeproj/project.pbxproj
@@ -39,6 +39,7 @@
 		49CD8F662C36A06B00E78E9E /* RepositoryViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49CD8F652C36A06B00E78E9E /* RepositoryViewCell.swift */; };
 		49D34A122E02B3C400563078 /* ErrorMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49D34A112E02B3C400563078 /* ErrorMessage.swift */; };
 		49D36C952E12A9FC00563078 /* StarredRepositoryRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49D36C942E12A9FC00563078 /* StarredRepositoryRequest.swift */; };
+		49D37DC52E14F5BB00563078 /* RemoveStarFromRepositoryRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49D37DC42E14F5BB00563078 /* RemoveStarFromRepositoryRequest.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -93,6 +94,7 @@
 		49CD8F652C36A06B00E78E9E /* RepositoryViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepositoryViewCell.swift; sourceTree = "<group>"; };
 		49D34A112E02B3C400563078 /* ErrorMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorMessage.swift; sourceTree = "<group>"; };
 		49D36C942E12A9FC00563078 /* StarredRepositoryRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StarredRepositoryRequest.swift; sourceTree = "<group>"; };
+		49D37DC42E14F5BB00563078 /* RemoveStarFromRepositoryRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoveStarFromRepositoryRequest.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -247,6 +249,7 @@
 				49CD8F5A2C2E83CC00E78E9E /* SearchRepositoriesRequest.swift */,
 				4934685A2DCB45BC001B6A95 /* RepositoryDetailRequest.swift */,
 				49C600AA2DE47DAB003052A4 /* AddStarToRepositoryRequest.swift */,
+				49D37DC42E14F5BB00563078 /* RemoveStarFromRepositoryRequest.swift */,
 				49D36C942E12A9FC00563078 /* StarredRepositoryRequest.swift */,
 			);
 			path = Request;
@@ -445,6 +448,7 @@
 				4984406C2DDDA98400AFB21A /* WireframeProtocol.swift in Sources */,
 				49CD8F5B2C2E83CC00E78E9E /* SearchRepositoriesRequest.swift in Sources */,
 				49CD8F572C2E573700E78E9E /* APIClient.swift in Sources */,
+				49D37DC52E14F5BB00563078 /* RemoveStarFromRepositoryRequest.swift in Sources */,
 				49CD8F592C2E581500E78E9E /* HTTPError.swift in Sources */,
 				498440702DDDAAF900AFB21A /* SearchRepositoryWireframe.swift in Sources */,
 				49CD8F5D2C2E83FE00E78E9E /* SearchRepositoriesResponse.swift in Sources */,

--- a/zozo-ios-engineer-codecheck/Data/Request/RemoveStarFromRepositoryRequest.swift
+++ b/zozo-ios-engineer-codecheck/Data/Request/RemoveStarFromRepositoryRequest.swift
@@ -1,0 +1,39 @@
+//
+//  RemoveStarFromRepositoryRequest.swift
+//  zozo-ios-engineer-codecheck
+//
+//  Created by yuki.hamada on 2025/05/26.
+//
+
+import Foundation
+
+struct RemoveStarFromRepositoryRequest: APIRequestProtocol {
+    let owner: String
+    let repo: String
+
+    init(owner: String, repo: String) {
+        self.owner = owner
+        self.repo = repo
+    }
+
+    typealias Response = EmptyResponse
+
+    var baseURL: URL {
+        guard let baseURL = URL(string: "https://api.github.com") else { fatalError("error baseURL") }
+        return baseURL
+    }
+
+    var path: String {
+        "/user/starred/\(self.owner)/\(self.repo)"
+    }
+
+    var method: HTTPMethod = .delete
+    var headers: [String: String] = [
+        "Accept": "application/vnd.github+json",
+        "Authorization": "Bearer \(GitHubAPIConfig.accessToken)",
+        "X-GitHub-Api-Version": "2022-11-28"
+    ]
+    var urlQueryItem: URLQueryItem? = nil
+
+    var body: Data?
+}

--- a/zozo-ios-engineer-codecheck/Feature/SearchRepository/SearchRepositoryViewModel.swift
+++ b/zozo-ios-engineer-codecheck/Feature/SearchRepository/SearchRepositoryViewModel.swift
@@ -89,6 +89,7 @@ final class SearchRepositoryViewModel: SearchRepositoryViewModelProtocol {
         switch state {
         case .success(var repositories):
             if !repositories.items[tappedCellIndex].isStarred {
+                // リポジトリにスターを付与
                 let addStarToRepositoryRequest: AddStarToRepositoryRequest = .init(owner: repositories.items[tappedCellIndex].owner.login, repo: repositories.items[tappedCellIndex].name)
                 do {
                     let response: Result<EmptyResponse, HTTPError> = try await apiClient.request(apiRequest: addStarToRepositoryRequest)
@@ -105,6 +106,7 @@ final class SearchRepositoryViewModel: SearchRepositoryViewModelProtocol {
                     state = .error(.init(title: HTTPError.unknownError.title, description: HTTPError.unknownError.errorDescription))
                 }
             } else {
+                // リポジトリからスターを削除
                 let removeStarFromRepositoryRequest: RemoveStarFromRepositoryRequest = .init(owner: repositories.items[tappedCellIndex].owner.login, repo: repositories.items[tappedCellIndex].name)
                 do {
                     let response: Result<EmptyResponse, HTTPError> = try await apiClient.request(apiRequest: removeStarFromRepositoryRequest)

--- a/zozo-ios-engineer-codecheck/Feature/SearchRepository/SearchRepositoryViewModel.swift
+++ b/zozo-ios-engineer-codecheck/Feature/SearchRepository/SearchRepositoryViewModel.swift
@@ -88,23 +88,38 @@ final class SearchRepositoryViewModel: SearchRepositoryViewModelProtocol {
     func starButtonTapped(tappedCellIndex: Int) async {
         switch state {
         case .success(var repositories):
-            let addStarToRepositoryRequest: AddStarToRepositoryRequest = .init(owner: repositories.items[tappedCellIndex].owner.login, repo: repositories.items[tappedCellIndex].name)
-            do {
-                let response: Result<EmptyResponse, HTTPError> = try await apiClient.request(apiRequest: addStarToRepositoryRequest)
-                switch response {
-                case .success(_):
-                    // TODO: スター解除機能を実装したら、リファクタリング検討する
-                    if !repositories.items[tappedCellIndex].isStarred {
+            if !repositories.items[tappedCellIndex].isStarred {
+                let addStarToRepositoryRequest: AddStarToRepositoryRequest = .init(owner: repositories.items[tappedCellIndex].owner.login, repo: repositories.items[tappedCellIndex].name)
+                do {
+                    let response: Result<EmptyResponse, HTTPError> = try await apiClient.request(apiRequest: addStarToRepositoryRequest)
+                    switch response {
+                    case .success(_):
                         repositories.items[tappedCellIndex].stargazersCount += 1
                         repositories.items[tappedCellIndex].isStarred = true
+                        state = .success(repositories)
+                    case .failure(let error):
+                        let errorMessage: ErrorMessage = .init(title: "\(error.title)", description: error.errorDescription)
+                        state = .error(errorMessage)
                     }
-                    state = .success(repositories)
-                case .failure(let error):
-                    let errorMessage: ErrorMessage = .init(title: "\(error.title)", description: error.errorDescription)
-                    state = .error(errorMessage)
+                } catch {
+                    state = .error(.init(title: HTTPError.unknownError.title, description: HTTPError.unknownError.errorDescription))
                 }
-            } catch {
-                state = .error(.init(title: HTTPError.unknownError.title, description: HTTPError.unknownError.errorDescription))
+            } else {
+                let removeStarFromRepositoryRequest: RemoveStarFromRepositoryRequest = .init(owner: repositories.items[tappedCellIndex].owner.login, repo: repositories.items[tappedCellIndex].name)
+                do {
+                    let response: Result<EmptyResponse, HTTPError> = try await apiClient.request(apiRequest: removeStarFromRepositoryRequest)
+                    switch response {
+                    case .success(_):
+                        repositories.items[tappedCellIndex].stargazersCount -= 1
+                        repositories.items[tappedCellIndex].isStarred = false
+                        state = .success(repositories)
+                    case .failure(let error):
+                        let errorMessage: ErrorMessage = .init(title: "\(error.title)", description: error.errorDescription)
+                        state = .error(errorMessage)
+                    }
+                } catch {
+                    state = .error(.init(title: HTTPError.unknownError.title, description: HTTPError.unknownError.errorDescription))
+                }
             }
         case .initial, .loading, .error:
             print("")


### PR DESCRIPTION
**https://github.com/hamadayuuki/zozo-ios-engineer-codecheck/pull/14, https://github.com/hamadayuuki/zozo-ios-engineer-codecheck/pull/15 をマージしてからマージする**

## 概要（一言で簡潔に）

リポジトリのスターを解除する

## 詳細

変更点は以下の通りです
- スター解除用のリクエストを実装
    - `RemoveStarFromRepositoryRequest`
- APIClient を使いスター解除のリクエストを送信

## スクリーンショット

| リポジトリのスターを解除 |
| --- |
| <img width = 300 src = "https://github.com/user-attachments/assets/13d8d11f-dd5d-4b7e-b22b-7607e4695e8f"> |


